### PR TITLE
Patch Issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /geocode
 
 COPY . . 
 
-RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}.zip\
+RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}{PATCH}.zip\
     && echo $FILE_NAME\
     && curl -O https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/$FILE_NAME\
     && unzip *.zip\
@@ -19,8 +19,8 @@ RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}.zip\
 
 RUN ./patch.sh
 
-ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}/fls/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}/lib/
+ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}{PATCH}/fls/
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}{PATCH}/lib/
 
 RUN pip install --upgrade pip \
     && pip install -e python-geosupport/.\

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN FILE_NAME=linux_geo${RELEASE}${PATCH}_${MAJOR}_${MINOR}${PATCH}.zip\
 
 RUN ./patch.sh
 
-ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/fls/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/lib/
+ENV GEOFILES=/geocode/version-${RELEASE}${PATCH}_${MAJOR}.${MINOR}${PATCH}/fls/
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}${PATCH}_${MAJOR}.${MINOR}${PATCH}/lib/
 
 RUN pip install --upgrade pip \
     && pip install -e python-geosupport/.\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.9-slim
 
-ARG RELEASE=21c
-ARG MAJOR=21
-ARG MINOR=3
-ARG PATCH=0
+ARG RELEASE=22a
+ARG MAJOR=22
+ARG MINOR=1
+ARG PATCH=2
 
 RUN apt update && apt install -y curl git unzip zip build-essential
 
@@ -11,7 +11,7 @@ WORKDIR /geocode
 
 COPY . . 
 
-RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}{PATCH}.zip\
+RUN FILE_NAME=linux_geo${RELEASE}${PATCH}_${MAJOR}_${MINOR}${PATCH}.zip\
     && echo $FILE_NAME\
     && curl -O https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/$FILE_NAME\
     && unzip *.zip\
@@ -19,8 +19,8 @@ RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}{PATCH}.zip\
 
 RUN ./patch.sh
 
-ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}{PATCH}/fls/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}{PATCH}/lib/
+ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/fls/
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/lib/
 
 RUN pip install --upgrade pip \
     && pip install -e python-geosupport/.\

--- a/patch.sh
+++ b/patch.sh
@@ -5,7 +5,7 @@ if [[ ${PATCH} = 0 ]]
     else
         echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
         mkdir linux_upad_tpad_${RELEASE}${PATCH}\
-        && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo${RELEASE}_${MAJOR}_${MINOR}${PATCH}.zip\
-        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/fls/\
+        && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo${RELEASE}${PATCH}_${MAJOR}_${MINOR}${PATCH}.zip\
+        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip /geocode/ \
         && rm -r linux_upad_tpad_${RELEASE}${PATCH}
     fi

--- a/patch.sh
+++ b/patch.sh
@@ -5,7 +5,7 @@ if [[ ${PATCH} = 0 ]]
     else
         echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
         mkdir linux_upad_tpad_${RELEASE}${PATCH}\
-        && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_upad_tpad_${RELEASE}${PATCH}.zip\
-        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}/fls/\
+        && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo${RELEASE}_${MAJOR}_${MINOR}${PATCH}.zip\
+        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/fls/\
         && rm -r linux_upad_tpad_${RELEASE}${PATCH}
     fi

--- a/patch.sh
+++ b/patch.sh
@@ -6,6 +6,6 @@ if [[ ${PATCH} = 0 ]]
         echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
         mkdir linux_upad_tpad_${RELEASE}${PATCH}\
         && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo${RELEASE}${PATCH}_${MAJOR}_${MINOR}${PATCH}.zip\
-        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip /geocode/ \
+        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}${PATCH}_${MAJOR}.${MINOR}${PATCH}/fls/ \
         && rm -r linux_upad_tpad_${RELEASE}${PATCH}
     fi


### PR DESCRIPTION
#19 see Amanda's writeup for more detailed

After some more investigation, I believe the deeper cause of the issue is in the patch logics. This part of pipeline was probably broken before but since most geosupport build does not have a patch number so it was circumvented.The question about this would be sustainable in the long run depends on the patch url is stable or not. 

[A successful github action run](https://github.com/NYCPlanning/docker-geosupport/runs/7412446783?check_suite_focus=true)  if anyone interested in the more detailed of the build. But based on the update on [Docker hub](https://hub.docker.com/r/nycplanning/docker-geosupport/tags), it should be successful. It should be noted when I tried to build this in local container it seems to run out of space at some point. 