### PR TITLE
fix failing build with UDAP release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN FILE_NAME=linux_geo${RELEASE}${PATCH}_${MAJOR}_${MINOR}${PATCH}.zip\
 
 RUN ./patch.sh
 
-ENV GEOFILES=/geocode/version-${RELEASE}${PATCH}_${MAJOR}.${MINOR}${PATCH}/fls/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}${PATCH}_${MAJOR}.${MINOR}${PATCH}/lib/
+ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}/fls/
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}/lib/
 
 RUN pip install --upgrade pip \
     && pip install -e python-geosupport/.\

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /geocode
 
 COPY . . 
 
-RUN FILE_NAME=linux_geo22a2_22_12.zip\
+RUN FILE_NAME=linux_geo${RELEASE}2_${MAJOR}_${MINOR}2.zip\
     && echo $FILE_NAME\
     && curl -O https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/$FILE_NAME\
     && unzip *.zip\
@@ -19,8 +19,8 @@ RUN FILE_NAME=linux_geo22a2_22_12.zip\
 
 RUN ./patch.sh
 
-ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}/fls/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}/lib/
+ENV GEOFILES=/geocode/version-${RELEASE}2_${MAJOR}.${MINOR}2/fls/
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}2_${MAJOR}.${MINOR}2/lib/
 
 RUN pip install --upgrade pip \
     && pip install -e python-geosupport/.\

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /geocode
 
 COPY . . 
 
-RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}.zip\
+RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}{PATCH}.zip\
     && echo $FILE_NAME\
     && curl -O https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/$FILE_NAME\
     && unzip *.zip\
@@ -19,8 +19,8 @@ RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}.zip\
 
 RUN ./patch.sh
 
-ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}/fls/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}/lib/
+ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}{PATCH}/fls/
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}{PATCH}/lib/
 
 RUN pip install --upgrade pip \
     && pip install -e python-geosupport/.\

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN FILE_NAME=linux_geo${RELEASE}${PATCH}_${MAJOR}_${MINOR}${PATCH}.zip\
 
 RUN ./patch.sh
 
-ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/fls/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/lib/
+ENV GEOFILES=/geocode/version-${RELEASE}${PATCH}_${MAJOR}.${MINOR}${PATCH}/fls/
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}${PATCH}_${MAJOR}.${MINOR}${PATCH}/lib/
 
 RUN pip install --upgrade pip \
     && pip install -e python-geosupport/.\

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /geocode
 
 COPY . . 
 
-RUN FILE_NAME=linux_geo${RELEASE}2_${MAJOR}_${MINOR}2.zip\
+RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}.zip\
     && echo $FILE_NAME\
     && curl -O https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/$FILE_NAME\
     && unzip *.zip\
@@ -19,8 +19,8 @@ RUN FILE_NAME=linux_geo${RELEASE}2_${MAJOR}_${MINOR}2.zip\
 
 RUN ./patch.sh
 
-ENV GEOFILES=/geocode/version-${RELEASE}2_${MAJOR}.${MINOR}2/fls/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}2_${MAJOR}.${MINOR}2/lib/
+ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}/fls/
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}/lib/
 
 RUN pip install --upgrade pip \
     && pip install -e python-geosupport/.\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.9-slim
 
-ARG RELEASE=21c
-ARG MAJOR=21
-ARG MINOR=3
-ARG PATCH=0
+ARG RELEASE=22a
+ARG MAJOR=22
+ARG MINOR=1
+ARG PATCH=2
 
 RUN apt update && apt install -y curl git unzip zip build-essential
 
@@ -11,7 +11,7 @@ WORKDIR /geocode
 
 COPY . . 
 
-RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}{PATCH}.zip\
+RUN FILE_NAME=linux_geo${RELEASE}${PATCH}_${MAJOR}_${MINOR}${PATCH}.zip\
     && echo $FILE_NAME\
     && curl -O https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/$FILE_NAME\
     && unzip *.zip\
@@ -19,8 +19,8 @@ RUN FILE_NAME=linux_geo${RELEASE}_${MAJOR}_${MINOR}{PATCH}.zip\
 
 RUN ./patch.sh
 
-ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}{PATCH}/fls/
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}{PATCH}/lib/
+ENV GEOFILES=/geocode/version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/fls/
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/geocode/version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/lib/
 
 RUN pip install --upgrade pip \
     && pip install -e python-geosupport/.\

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /geocode
 
 COPY . . 
 
-RUN FILE_NAME=linux_geo${RELEASE}${PATCH}_${MAJOR}_${MINOR}${PATCH}.zip\
+RUN FILE_NAME=linux_geo22a2_22_12.zip\
     && echo $FILE_NAME\
     && curl -O https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/$FILE_NAME\
     && unzip *.zip\

--- a/patch.sh
+++ b/patch.sh
@@ -6,6 +6,6 @@ if [[ ${PATCH} = 0 ]]
         echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
         mkdir linux_upad_tpad_${RELEASE}${PATCH}\
         && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_upad_tpad_${RELEASE}${PATCH}.zip\
-        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}/fls/\
+        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}2_${MAJOR}.${MINOR}2/fls/\
         && rm -r linux_upad_tpad_${RELEASE}${PATCH}
     fi

--- a/patch.sh
+++ b/patch.sh
@@ -5,7 +5,7 @@ if [[ ${PATCH} = 0 ]]
     else
         echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
         mkdir linux_upad_tpad_${RELEASE}${PATCH}\
-        && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo${RELEASE}_${MAJOR}_${MINOR}${PATCH}.zip\
-        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/fls/\
+        && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo${RELEASE}${PATCH}_${MAJOR}_${MINOR}${PATCH}.zip\
+        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip /geocode/ \
         && rm -r linux_upad_tpad_${RELEASE}${PATCH}
     fi

--- a/patch.sh
+++ b/patch.sh
@@ -5,7 +5,7 @@ if [[ ${PATCH} = 0 ]]
     else
         echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
         mkdir linux_upad_tpad_${RELEASE}${PATCH}\
-        && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_upad_tpad_${RELEASE}${PATCH}.zip\
-        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}/fls/\
+        && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo${RELEASE}_${MAJOR}_${MINOR}${PATCH}.zip\
+        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}${PATCH}/fls/\
         && rm -r linux_upad_tpad_${RELEASE}${PATCH}
     fi

--- a/patch.sh
+++ b/patch.sh
@@ -6,6 +6,6 @@ if [[ ${PATCH} = 0 ]]
         echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
         mkdir linux_upad_tpad_${RELEASE}${PATCH}\
         && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo${RELEASE}${PATCH}_${MAJOR}_${MINOR}${PATCH}.zip\
-        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip /geocode/ \
+        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}${PATCH}_${MAJOR}.${MINOR}${PATCH}/fls/ \
         && rm -r linux_upad_tpad_${RELEASE}${PATCH}
     fi

--- a/patch.sh
+++ b/patch.sh
@@ -5,7 +5,7 @@ if [[ ${PATCH} = 0 ]]
     else
         echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
         mkdir linux_upad_tpad_${RELEASE}${PATCH}\
-        && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo${RELEASE}${PATCH}_${MAJOR}_${MINOR}${PATCH}.zip\
-        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}${PATCH}_${MAJOR}.${MINOR}${PATCH}/fls/ \
+        && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_upad_tpad_${RELEASE}${PATCH}.zip\
+        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}/fls/\
         && rm -r linux_upad_tpad_${RELEASE}${PATCH}
     fi

--- a/patch.sh
+++ b/patch.sh
@@ -6,6 +6,6 @@ if [[ ${PATCH} = 0 ]]
         echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
         mkdir linux_upad_tpad_${RELEASE}${PATCH}\
         && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_upad_tpad_${RELEASE}${PATCH}.zip\
-        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}2_${MAJOR}.${MINOR}2/fls/\
+        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}/fls/\
         && rm -r linux_upad_tpad_${RELEASE}${PATCH}
     fi

--- a/versions.py
+++ b/versions.py
@@ -11,22 +11,27 @@ releases = [
     if "Release" in i.string
 ]
 
-minior_lookup = {"a": 1, "b": 2, "c": 3, "d": 4}
+minior_lookup = {
+    'a': 1,
+    'b': 2, 
+    'c': 3,
+    'd': 4
+}
 
 if len(releases) > 1:
     # If more than 1 item in release
     # then there must be a UPAD present
     # Check if they are the same release
     r1 = releases[0][:3]
-    r2 = releases[1].split(" ")[-1][:3]  # expecting strings like "upad / tpad  22c4'"
+    r2 = releases[1].split(" ")[-1][:3] # expecting strings like "upad / tpad  22c4'"
     print("what are releases", releases)
     print("what is r1", r1)
     print("what is r2", r2)
-
+    
     if r1 != r2:
         release = releases[0]
     else:
-        release = max(releases, key=len)
+        release=max(releases, key=len)
     print("chosen release", release)
 
     if len(release) == 4:
@@ -34,17 +39,14 @@ if len(releases) > 1:
             RELEASE=release[:3],
             MAJOR=release[:2],
             MINOR=minior_lookup.get(release[2]),
-            PATCH=release[3],
+            PATCH=release[3]
         )
     if len(release) == 3:
         versions = dict(
             RELEASE=release[:3],
             MAJOR=release[:2],
             MINOR=minior_lookup.get(release[2]),
-            PATCH=0,
+            PATCH=0
         )
-
-    print(
-        f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}",
-        file=sys.stdout,
-    )
+    
+    print(f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}", file=sys.stdout)

--- a/versions.py
+++ b/versions.py
@@ -24,6 +24,10 @@ if len(releases) > 1:
     # Check if they are the same release
     r1 = releases[0][2]
     r2 = releases[1][2]
+    print("what are releases", releases)
+    print("what is r1", r1)
+    print("what is r2", r2)
+    
     if r1 != r2:
         release = releases[0]
     else:

--- a/versions.py
+++ b/versions.py
@@ -32,6 +32,7 @@ if len(releases) > 1:
         release = releases[0]
     else:
         release=max(releases, key=len)
+    print("chosen release", release)
 
     if len(release) == 4:
         versions = dict(

--- a/versions.py
+++ b/versions.py
@@ -38,7 +38,7 @@ if len(releases) > 1:
             RELEASE=release[:3],
             MAJOR=release[:2],
             MINOR=minior_lookup.get(release[2]),
-            PATCH=9,
+            PATCH=release[3]
         )
     if len(release) == 3:
         versions = dict(

--- a/versions.py
+++ b/versions.py
@@ -11,27 +11,22 @@ releases = [
     if "Release" in i.string
 ]
 
-minior_lookup = {
-    'a': 1,
-    'b': 2, 
-    'c': 3,
-    'd': 4
-}
+minior_lookup = {"a": 1, "b": 2, "c": 3, "d": 4}
 
 if len(releases) > 1:
     # If more than 1 item in release
     # then there must be a UPAD present
     # Check if they are the same release
-    r1 = releases[0][2]
-    r2 = releases[1].split(" ")[-1][2] # expecting strings like "upad / tpad  22c4'"
+    r1 = releases[0][:3]
+    r2 = releases[1].split(" ")[-1][:3]  # expecting strings like "upad / tpad  22c4'"
     print("what are releases", releases)
     print("what is r1", r1)
     print("what is r2", r2)
-    
+
     if r1 != r2:
         release = releases[0]
     else:
-        release=max(releases, key=len)
+        release = max(releases, key=len)
     print("chosen release", release)
 
     if len(release) == 4:
@@ -39,14 +34,17 @@ if len(releases) > 1:
             RELEASE=release[:3],
             MAJOR=release[:2],
             MINOR=minior_lookup.get(release[2]),
-            PATCH=release[3]
+            PATCH=release[3],
         )
     if len(release) == 3:
         versions = dict(
             RELEASE=release[:3],
             MAJOR=release[:2],
             MINOR=minior_lookup.get(release[2]),
-            PATCH=0
+            PATCH=0,
         )
-    
-    print(f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}", file=sys.stdout)
+
+    print(
+        f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}",
+        file=sys.stdout,
+    )

--- a/versions.py
+++ b/versions.py
@@ -38,7 +38,7 @@ if len(releases) > 1:
             RELEASE=release[:3],
             MAJOR=release[:2],
             MINOR=minior_lookup.get(release[2]),
-            PATCH=release[3]
+            PATCH=9,
         )
     if len(release) == 3:
         versions = dict(

--- a/versions.py
+++ b/versions.py
@@ -23,7 +23,7 @@ if len(releases) > 1:
     # then there must be a UPAD present
     # Check if they are the same release
     r1 = releases[0][2]
-    r2 = releases[1][2]
+    r2 = releases[1].split(" ")[-1][2] # expecting strings like "upad / tpad  22c4'"
     print("what are releases", releases)
     print("what is r1", r1)
     print("what is r2", r2)


### PR DESCRIPTION
* this work was originally meant to fix handling of UDAP releases
* issue seemed to stem from parsing of table with Release XXX values on [NYC Planning Open Data website](https://www.nyc.gov/site/planning/data-maps/open-data/dwn-gde-home.page)
* due to the release of 23A, UDAP ingestion is no longer urgent. iceboxing this work in favor of fixing builds on main branch 