### PR TITLE
fix build failing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
+# Exit when any command fails
+set -e
+# Keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# Echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
 function docker_tag_exists() {
-    curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 > /dev/null
+    curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 >/dev/null
 }
 
 VERSIONSTRING=$(python3 versions.py)
@@ -10,17 +16,17 @@ export VERSION=$MAJOR.$MINOR.$PATCH
 
 if docker_tag_exists nycplanning/docker-geosupport $VERSION; then
     echo "nycplanning/docker-geosupport:$VERSION already exist"
-else 
+else
     # State version name
     echo "$VERSIONSTRING"
     echo "$VERSION"
 
     # Log into Github registry
     echo "$GITHUB_TOKEN" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-    
+
     GITHUB_IMAGE_NAME=ghcr.io/nycplanning/docker-geosupport/geosupport
     DOCKER_IMAGE_NAME=nycplanning/docker-geosupport
-    
+
     # Build image
     docker build \
         --build-arg RELEASE=$RELEASE \

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,9 @@ function docker_tag_exists() {
     curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 >/dev/null
 }
 
-VERSIONSTRING=$(python3 versions.py)
+# VERSIONSTRING=$(python3 versions.py)
+python3 versions.py
+
 export $(echo "$VERSIONSTRING" | sed 's/#.*//g' | xargs)
 export VERSION=$MAJOR.$MINOR.$PATCH
 

--- a/build.sh
+++ b/build.sh
@@ -10,8 +10,7 @@ function docker_tag_exists() {
     curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 >/dev/null
 }
 
-# VERSIONSTRING=$(python3 versions.py)
-python3 versions.py
+VERSIONSTRING=$(python3 versions.py)
 echo "VERSIONSTRING from versions.py is $VERSIONSTRING"
 
 export $(echo "$VERSIONSTRING" | sed 's/#.*//g' | xargs)

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,7 @@ function docker_tag_exists() {
 
 # VERSIONSTRING=$(python3 versions.py)
 python3 versions.py
+echo "VERSIONSTRING from versions.py is $VERSIONSTRING"
 
 export $(echo "$VERSIONSTRING" | sed 's/#.*//g' | xargs)
 export VERSION=$MAJOR.$MINOR.$PATCH

--- a/versions.py
+++ b/versions.py
@@ -1,6 +1,8 @@
+# Get the relevant release details from the Geosupport Open Data page
+# and set an environment variable
 import requests
 from bs4 import BeautifulSoup
-import sys
+import os
 
 GEOSUPPORT_RELEASE_URL = (
     "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-gde-home.page"
@@ -59,7 +61,5 @@ if __name__ == "__main__":
                 PATCH=0,
             )
 
-        print(
-            f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}",
-            file=sys.stdout,
-        )
+        version_string = f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}"
+        os.environ["VERSIONSTRING"] = version_string

--- a/versions.py
+++ b/versions.py
@@ -26,9 +26,11 @@ if len(releases) > 1:
     # r1 = releases[0][:3]
     # r2 = releases[1].split(" ")[-1][:3]  # expecting strings like "upad / tpad  22c4'"
     if r1 != r2:
+        # posted UPAD is not meant for current release
         release = releases[0]
     else:
-        release = max(releases, key=len)
+        # UPAD should be incorporated
+        release = releases[1]
     print(f"{release=}")
 
     if len(release) == 4:

--- a/versions.py
+++ b/versions.py
@@ -48,10 +48,11 @@ if __name__ == "__main__":
         # then there must be a UPAD present
         # Check if they are the same release
         primary_release = releases[0]
-        upad_release = releases[1].split(" ")[-1][:3]  # expecting "upad / tpad  22c4"
+        upad_release = releases[1].split(" ")[-1]  # expecting "upad / tpad  22c4"
         upad_primary_release = upad_release[:2]
         print(f"{primary_release=}")
         print(f"{upad_release=}")
+        print(f"{upad_primary_release=}")
 
         if primary_release == upad_primary_release:
             print("Matching Primary and UPAD releases")

--- a/versions.py
+++ b/versions.py
@@ -4,7 +4,9 @@ import requests
 from bs4 import BeautifulSoup
 import os
 
-IGNORE_UPAD_RELEASE = False  # TODO this is temporary while 2022 UPAD needs to be built
+IGNORE_UPAD_RELEASE = (
+    False  # TODO this is temporary while an image with 22c4 UPAD needs to be built
+)
 
 CALLER_ENVIRONMENT_VARIABLE_NAME = "VERSIONSTRING"
 GEOSUPPORT_RELEASE_URL = (
@@ -58,7 +60,7 @@ if __name__ == "__main__":
         else:
             print("WARNING! Mismatch between posted Primary and UPAD releases")
             # posted UPAD is not meant for current release
-            # TODO this is temporary while 2022 UPAD needs to be built
+            # TODO this is temporary while an image with 22c4 UPAD needs to be built
             if IGNORE_UPAD_RELEASE:
                 print("Ignoring UPAD release")
                 release = primary_release

--- a/versions.py
+++ b/versions.py
@@ -2,7 +2,7 @@
 # and set an environment variable
 import requests
 from bs4 import BeautifulSoup
-import os
+import sys
 
 IGNORE_UPAD_RELEASE = (
     False  # TODO this is temporary while an image with 22c4 UPAD needs to be built
@@ -89,4 +89,4 @@ if __name__ == "__main__":
             raise ValueError(f"Got release string with unexpected length: {release=}")
 
     version_string = f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}"
-    os.environ[CALLER_ENVIRONMENT_VARIABLE_NAME] = version_string
+    print(version_string, file=sys.stdout)

--- a/versions.py
+++ b/versions.py
@@ -90,5 +90,3 @@ if __name__ == "__main__":
 
     version_string = f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}"
     os.environ[CALLER_ENVIRONMENT_VARIABLE_NAME] = version_string
-
-    raise InterruptedError(f"DEBUG\n\t{version_string=}")

--- a/versions.py
+++ b/versions.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         if "Release" in i.string
     ]
 
-    print(f"Release titles from Open Data table: {releases}")
+    logging.debug(f"Release titles from Open Data table: {releases}")
 
     if len(releases) == 1:
         # only one release section present

--- a/versions.py
+++ b/versions.py
@@ -12,7 +12,7 @@ logging.basicConfig(
 )
 
 IGNORE_UPAD_RELEASE = (
-    False  # TODO this is temporary while an image with 22c4 UPAD needs to be built
+    True  # TODO this is temporary while an image with 22c4 UPAD needs to be built
 )
 
 CALLER_ENVIRONMENT_VARIABLE_NAME = "VERSIONSTRING"
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         if "Release" in i.string
     ]
 
-    logging.debug(f"Release titles from Open Data table: {releases}")
+    logging.info(f"Release titles from Open Data table: {releases}")
 
     if len(releases) == 1:
         # only one release section present
@@ -58,27 +58,27 @@ if __name__ == "__main__":
         upad_release = releases[1].split(" ")[-1]  # expecting "upad / tpad  22c4"
         upad_primary_release = upad_release[0:3]
 
-        logging.debug(f"{primary_release=}")
-        logging.debug(f"{upad_release=}")
-        logging.debug(f"{upad_primary_release=}")
+        logging.info(f"{primary_release=}")
+        logging.info(f"{upad_release=}")
+        logging.info(f"{upad_primary_release=}")
 
         if primary_release == upad_primary_release:
-            logging.debug("Matching Primary and UPAD's Primary releases")
+            logging.info("Matching Primary and UPAD's Primary releases")
             # UPAD should be incorporated
             release = upad_release
         else:
-            logging.debug("WARNING! Mismatch between posted Primary and UPAD releases")
+            logging.info("WARNING! Mismatch between posted Primary and UPAD releases")
             # posted UPAD is not meant for current release
             # TODO this is temporary while an image with 22c4 UPAD needs to be built
             if IGNORE_UPAD_RELEASE:
-                logging.debug("Ignoring UPAD release")
+                logging.info("Ignoring UPAD release")
                 release = primary_release
             else:
                 # build for the posted UPAD
-                logging.debug("Prioritizing UPAD release")
+                logging.info("Prioritizing UPAD release")
                 release = upad_release
 
-        logging.debug(f"{release=}")
+        logging.info(f"{release=}")
         if len(release) == 4:  # is a UPAD version
             versions = dict(
                 RELEASE=release[:3],

--- a/versions.py
+++ b/versions.py
@@ -2,53 +2,64 @@ import requests
 from bs4 import BeautifulSoup
 import sys
 
-MINOR_LETTER_LOOKUP = {"a": 1, "b": 2, "c": 3, "d": 4}
+GEOSUPPORT_RELEASE_URL = (
+    "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-gde-home.page"
+)
+# to convert a release letter to a number for the docker image tag
+MINOR_LETTER_LOOKUP = {
+    "a": 1,
+    "b": 2,
+    "c": 3,
+    "d": 4,
+}
 
-url = "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-gde-home.page"
-soup = BeautifulSoup(requests.get(url).content, features="html.parser")
-table = soup.find_all("table", class_="table table-outline-border")[0]
-releases = [
-    i.string.replace("Release", "").strip().lower()
-    for i in table.find_all("th")
-    if "Release" in i.string
-]
-
-print(f"Release titles from Open Data table: {releases}")
-
-if len(releases) > 1:
-    # If more than 1 item in release
-    # then there must be a UPAD present
-    # Check if they are the same release
-    r1 = releases[0][2]
-    r2 = releases[1][2]
-    print(f"{r1=}")
-    print(f"{r2=}")
-    # r1 = releases[0][:3]
-    # r2 = releases[1].split(" ")[-1][:3]  # expecting strings like "upad / tpad  22c4'"
-    if r1 != r2:
-        # posted UPAD is not meant for current release
-        release = releases[0]
-    else:
-        # UPAD should be incorporated
-        release = releases[1]
-    print(f"{release=}")
-
-    if len(release) == 4:
-        versions = dict(
-            RELEASE=release[:3],
-            MAJOR=release[:2],
-            MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
-            PATCH=release[3],
-        )
-    if len(release) == 3:
-        versions = dict(
-            RELEASE=release[:3],
-            MAJOR=release[:2],
-            MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
-            PATCH=0,
-        )
-
-    print(
-        f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}",
-        file=sys.stdout,
+if __name__ == "__main__":
+    soup = BeautifulSoup(
+        requests.get(GEOSUPPORT_RELEASE_URL).content, features="html.parser"
     )
+    table = soup.find_all("table", class_="table table-outline-border")[0]
+    releases = [
+        i.string.replace("Release", "").strip().lower()
+        for i in table.find_all("th")
+        if "Release" in i.string
+    ]
+
+    print(f"Release titles from Open Data table: {releases}")
+
+    if len(releases) > 1:
+        # If more than 1 item in release
+        # then there must be a UPAD present
+        # Check if they are the same release
+        r1 = releases[0][2]
+        r2 = releases[1][2]
+        print(f"{r1=}")
+        print(f"{r2=}")
+        # r1 = releases[0][:3]
+        # r2 = releases[1].split(" ")[-1][:3]  # expecting strings like "upad / tpad  22c4'"
+        if r1 != r2:
+            # posted UPAD is not meant for current release
+            release = releases[0]
+        else:
+            # UPAD should be incorporated
+            release = releases[1]
+        print(f"{release=}")
+
+        if len(release) == 4:
+            versions = dict(
+                RELEASE=release[:3],
+                MAJOR=release[:2],
+                MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
+                PATCH=release[3],
+            )
+        if len(release) == 3:
+            versions = dict(
+                RELEASE=release[:3],
+                MAJOR=release[:2],
+                MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
+                PATCH=0,
+            )
+
+        print(
+            f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}",
+            file=sys.stdout,
+        )

--- a/versions.py
+++ b/versions.py
@@ -48,20 +48,23 @@ if __name__ == "__main__":
         # Check if they are the same release
         primary_release = releases[0]
         upad_release = releases[1].split(" ")[-1][:3]  # expecting "upad / tpad  22c4"
+        upad_primary_release = upad_release[:2]
+        print(f"{primary_release=}")
+        print(f"{upad_release=}")
 
-        r1 = primary_release[2]
-        r2 = upad_release[2]
-        print(f"{r1=}")
-        print(f"{r2=}")
-        if r1 != r2:
+        if primary_release != upad_primary_release:
+            print("WARNING! Mismatch between posted Primary and UPAD releases")
             # posted UPAD is not meant for current release
             if IGNORE_UPAD_RELEASE:
+                print("Ignoring UPAD release")
                 release = primary_release
             else:
                 # build for the posted UPAD
                 # TODO this is temporary
+                print("Prioritizing UPAD release")
                 release = upad_release
         else:
+            print("Matching Primary and UPAD releases")
             # UPAD should be incorporated
             release = upad_release
         print(f"{release=}")

--- a/versions.py
+++ b/versions.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         # Check if they are the same release
         primary_release = releases[0]
         upad_release = releases[1].split(" ")[-1]  # expecting "upad / tpad  22c4"
-        upad_primary_release = upad_release[:2]
+        upad_primary_release = upad_release[0:3]
         print(f"{primary_release=}")
         print(f"{upad_release=}")
         print(f"{upad_primary_release=}")

--- a/versions.py
+++ b/versions.py
@@ -2,6 +2,8 @@ import requests
 from bs4 import BeautifulSoup
 import sys
 
+MINOR_LETTER_LOOKUP = {"a": 1, "b": 2, "c": 3, "d": 4}
+
 url = "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-gde-home.page"
 soup = BeautifulSoup(requests.get(url).content, features="html.parser")
 table = soup.find_all("table", class_="table table-outline-border")[0]
@@ -11,7 +13,7 @@ releases = [
     if "Release" in i.string
 ]
 
-minior_lookup = {"a": 1, "b": 2, "c": 3, "d": 4}
+print(f"Release titles from Open Data table: {releases}")
 
 if len(releases) > 1:
     # If more than 1 item in release
@@ -19,23 +21,28 @@ if len(releases) > 1:
     # Check if they are the same release
     r1 = releases[0][2]
     r2 = releases[1][2]
+    print(f"{r1=}")
+    print(f"{r2=}")
+    # r1 = releases[0][:3]
+    # r2 = releases[1].split(" ")[-1][:3]  # expecting strings like "upad / tpad  22c4'"
     if r1 != r2:
         release = releases[0]
     else:
         release = max(releases, key=len)
+    print(f"{release=}")
 
     if len(release) == 4:
         versions = dict(
             RELEASE=release[:3],
             MAJOR=release[:2],
-            MINOR=minior_lookup.get(release[2]),
+            MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
             PATCH=release[3],
         )
     if len(release) == 3:
         versions = dict(
             RELEASE=release[:3],
             MAJOR=release[:2],
-            MINOR=minior_lookup.get(release[2]),
+            MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
             PATCH=0,
         )
 

--- a/versions.py
+++ b/versions.py
@@ -11,12 +11,7 @@ releases = [
     if "Release" in i.string
 ]
 
-minior_lookup = {
-    'a': 1,
-    'b': 2, 
-    'c': 3,
-    'd': 4
-}
+minior_lookup = {"a": 1, "b": 2, "c": 3, "d": 4}
 
 if len(releases) > 1:
     # If more than 1 item in release
@@ -27,21 +22,24 @@ if len(releases) > 1:
     if r1 != r2:
         release = releases[0]
     else:
-        release=max(releases, key=len)
+        release = max(releases, key=len)
 
     if len(release) == 4:
         versions = dict(
             RELEASE=release[:3],
             MAJOR=release[:2],
             MINOR=minior_lookup.get(release[2]),
-            PATCH=release[3]
+            PATCH=release[3],
         )
     if len(release) == 3:
         versions = dict(
             RELEASE=release[:3],
             MAJOR=release[:2],
             MINOR=minior_lookup.get(release[2]),
-            PATCH=0
+            PATCH=0,
         )
-    
-    print(f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}", file=sys.stdout)
+
+    print(
+        f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}",
+        file=sys.stdout,
+    )

--- a/versions.py
+++ b/versions.py
@@ -58,27 +58,27 @@ if __name__ == "__main__":
         upad_release = releases[1].split(" ")[-1]  # expecting "upad / tpad  22c4"
         upad_primary_release = upad_release[0:3]
 
-        logging.info(f"{primary_release=}")
-        logging.info(f"{upad_release=}")
-        logging.info(f"{upad_primary_release=}")
+        logging.debug(f"{primary_release=}")
+        logging.debug(f"{upad_release=}")
+        logging.debug(f"{upad_primary_release=}")
 
         if primary_release == upad_primary_release:
-            logging.info("Matching Primary and UPAD's Primary releases")
+            logging.debug("Matching Primary and UPAD's Primary releases")
             # UPAD should be incorporated
             release = upad_release
         else:
-            logging.info("WARNING! Mismatch between posted Primary and UPAD releases")
+            logging.debug("WARNING! Mismatch between posted Primary and UPAD releases")
             # posted UPAD is not meant for current release
             # TODO this is temporary while an image with 22c4 UPAD needs to be built
             if IGNORE_UPAD_RELEASE:
-                logging.info("Ignoring UPAD release")
+                logging.debug("Ignoring UPAD release")
                 release = primary_release
             else:
                 # build for the posted UPAD
-                logging.info("Prioritizing UPAD release")
+                logging.debug("Prioritizing UPAD release")
                 release = upad_release
 
-        logging.info(f"{release=}")
+        logging.debug(f"{release=}")
         if len(release) == 4:  # is a UPAD version
             versions = dict(
                 RELEASE=release[:3],

--- a/versions.py
+++ b/versions.py
@@ -47,12 +47,10 @@ if __name__ == "__main__":
         # then there must be a UPAD present
         # Check if they are the same release
         primary_release = releases[0]
-        upad_release = releases[0].split(" ")[-1][
-            :3
-        ]  # expecting strings like "upad / tpad  22c4'"
+        upad_release = releases[1].split(" ")[-1][:3]  # expecting "upad / tpad  22c4"
 
-        r1 = primary_release[-2]
-        r2 = upad_release[-2]
+        r1 = primary_release[2]
+        r2 = upad_release[2]
         print(f"{r1=}")
         print(f"{r2=}")
         if r1 != r2:

--- a/versions.py
+++ b/versions.py
@@ -53,13 +53,14 @@ if __name__ == "__main__":
                 MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
                 PATCH=release[3],
             )
-        if len(release) == 3:
+        elif len(release) == 3:
             versions = dict(
                 RELEASE=release[:3],
                 MAJOR=release[:2],
                 MINOR=MINOR_LETTER_LOOKUP.get(release[2]),
                 PATCH=0,
             )
-
+        else:
+            raise ValueError(f"Got release string with odd length: {release=}")
         version_string = f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}"
         os.environ["VERSIONSTRING"] = version_string

--- a/versions.py
+++ b/versions.py
@@ -1,8 +1,15 @@
 # Get the relevant release details from the Geosupport Open Data page
 # and set an environment variable
+import sys
+import logging
 import requests
 from bs4 import BeautifulSoup
-import sys
+
+logging.basicConfig(
+    level="INFO",
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 
 IGNORE_UPAD_RELEASE = (
     False  # TODO this is temporary while an image with 22c4 UPAD needs to be built
@@ -50,27 +57,28 @@ if __name__ == "__main__":
         primary_release = releases[0]
         upad_release = releases[1].split(" ")[-1]  # expecting "upad / tpad  22c4"
         upad_primary_release = upad_release[0:3]
-        print(f"{primary_release=}")
-        print(f"{upad_release=}")
-        print(f"{upad_primary_release=}")
+
+        logging.info(f"{primary_release=}")
+        logging.info(f"{upad_release=}")
+        logging.info(f"{upad_primary_release=}")
 
         if primary_release == upad_primary_release:
-            print("Matching Primary and UPAD's Primary releases")
+            logging.info("Matching Primary and UPAD's Primary releases")
             # UPAD should be incorporated
             release = upad_release
         else:
-            print("WARNING! Mismatch between posted Primary and UPAD releases")
+            logging.info("WARNING! Mismatch between posted Primary and UPAD releases")
             # posted UPAD is not meant for current release
             # TODO this is temporary while an image with 22c4 UPAD needs to be built
             if IGNORE_UPAD_RELEASE:
-                print("Ignoring UPAD release")
+                logging.info("Ignoring UPAD release")
                 release = primary_release
             else:
                 # build for the posted UPAD
-                print("Prioritizing UPAD release")
+                logging.info("Prioritizing UPAD release")
                 release = upad_release
 
-        print(f"{release=}")
+        logging.info(f"{release=}")
         if len(release) == 4:  # is a UPAD version
             versions = dict(
                 RELEASE=release[:3],

--- a/versions.py
+++ b/versions.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
         print(f"{upad_primary_release=}")
 
         if primary_release == upad_primary_release:
-            print("Matching Primary and UPAD releases")
+            print("Matching Primary and UPAD's Primary releases")
             # UPAD should be incorporated
             release = upad_release
         else:

--- a/versions.py
+++ b/versions.py
@@ -4,9 +4,8 @@ import requests
 from bs4 import BeautifulSoup
 import os
 
-IGNORE_UPAD_RELEASE = (
-    False  # TODO this is temporary while primary and UPAD releases are out of sync
-)
+IGNORE_UPAD_RELEASE = False  # TODO this is temporary while 2022 UPAD needs to be built
+
 CALLER_ENVIRONMENT_VARIABLE_NAME = "VERSIONSTRING"
 GEOSUPPORT_RELEASE_URL = (
     "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-gde-home.page"
@@ -52,24 +51,24 @@ if __name__ == "__main__":
         print(f"{primary_release=}")
         print(f"{upad_release=}")
 
-        if primary_release != upad_primary_release:
+        if primary_release == upad_primary_release:
+            print("Matching Primary and UPAD releases")
+            # UPAD should be incorporated
+            release = upad_release
+        else:
             print("WARNING! Mismatch between posted Primary and UPAD releases")
             # posted UPAD is not meant for current release
+            # TODO this is temporary while 2022 UPAD needs to be built
             if IGNORE_UPAD_RELEASE:
                 print("Ignoring UPAD release")
                 release = primary_release
             else:
                 # build for the posted UPAD
-                # TODO this is temporary
                 print("Prioritizing UPAD release")
                 release = upad_release
-        else:
-            print("Matching Primary and UPAD releases")
-            # UPAD should be incorporated
-            release = upad_release
-        print(f"{release=}")
 
-        if len(release) == 4:
+        print(f"{release=}")
+        if len(release) == 4:  # is a UPAD version
             versions = dict(
                 RELEASE=release[:3],
                 MAJOR=release[:2],
@@ -84,7 +83,7 @@ if __name__ == "__main__":
                 PATCH=0,
             )
         else:
-            raise ValueError(f"Got release string with odd length: {release=}")
+            raise ValueError(f"Got release string with unexpected length: {release=}")
 
     version_string = f"RELEASE={versions['RELEASE']} MAJOR={versions['MAJOR']} MINOR={versions['MINOR']} PATCH={versions['PATCH']}"
     os.environ[CALLER_ENVIRONMENT_VARIABLE_NAME] = version_string


### PR DESCRIPTION
## issue
* build action is failing on main branch
* build action also fails when a UPAD release is available
* we need but do not have an image version 22.3.4 (aka 22c release with 22c4 UPAD) for https://github.com/NYCPlanning/db-developments/pull/619

## changes
* improve parsing of text on [Geosupport Open Data site](https://www.nyc.gov/site/planning/data-maps/open-data/dwn-gde-home.page) to detect and handle UPAD releases
* allow for forcing a UPAD-based build while newer primary release is present
  * e.g. build based on 22C4 UPAD even though 23A release is preset
* autoformat edited (using `black` for python files and [shell-format vs code extension](https://github.com/foxundermoon/vs-shell-format) for bash scripts)

## tests
* [build of 22.3.4](https://github.com/NYCPlanning/docker-geosupport/actions/runs/4178136958/jobs/7236572732#step:4:13)
* [build of 23.1.0](https://github.com/NYCPlanning/docker-geosupport/actions/runs/4178202259/jobs/7236714224#step:4:812)
* screenshot from dockerhub after the two builds linked above:
  * <img width="256" alt="image" src="https://user-images.githubusercontent.com/7444289/218867978-dcf9a85b-d6ad-4641-b0fa-08b8be2f2882.png">

