### PR TITLE
fix link used for upad file

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-if [[ ${PATCH} = 0 ]]
-    then
-        echo "NO UPAD AVAILABLE YET ..."
-    else
-        echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
-        mkdir linux_upad_tpad_${RELEASE}${PATCH}\
-        && curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_upad_tpad_${RELEASE}${PATCH}.zip\
-        && unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}/fls/\
-        && rm -r linux_upad_tpad_${RELEASE}${PATCH}
-    fi
+if [[ ${PATCH} = 0 ]]; then
+    echo "NO UPAD AVAILABLE YET ..."
+else
+    echo "YES UPAD IS AVAILABLE linux_upad_tpad_${RELEASE}${PATCH}"
+    mkdir linux_upad_tpad_${RELEASE}${PATCH} &&
+        curl -o linux_upad_tpad_${RELEASE}${PATCH}/linux_upad_tpad_${RELEASE}${PATCH}.zip https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/linux_upad_tpad_${RELEASE}${PATCH}.zip &&
+        unzip -o linux_upad_tpad_${RELEASE}${PATCH}/*.zip -d version-${RELEASE}_${MAJOR}.${MINOR}/fls/ &&
+        rm -r linux_upad_tpad_${RELEASE}${PATCH}
+fi


### PR DESCRIPTION
## motivations
- builds are failing since first 23A UPAD release (23A1) due to apparent deprecation of the asset link

## changes
- use new bytes link

## tests
- [successful build](https://github.com/NYCPlanning/docker-geosupport/actions/runs/4275891385/jobs/7443592014#step:4:859) of 23A1 and push to [dockerhub](https://hub.docker.com/r/nycplanning/docker-geosupport/tags) as `23.1.1` and `latest`